### PR TITLE
[DOM-68737] Refactor version_hash_additional_context to use bytes

### DIFF
--- a/flytekit/configuration/plugin.py
+++ b/flytekit/configuration/plugin.py
@@ -61,7 +61,7 @@ class FlytekitPluginProtocol(Protocol):
         """Get default cache policies for tasks."""
 
     @staticmethod
-    def get_additional_context_for_version_hash(entity: Union[PythonAutoContainerTask, WorkflowBase]) -> List[str]:
+    def get_additional_context_for_version_hash(entity: Union[PythonAutoContainerTask, WorkflowBase]) -> List[bytes]:
         """Get additional context to be used for calculating the version hash."""
 
     def get_additional_info_for_execution(
@@ -125,7 +125,7 @@ class FlytekitPlugin:
         return []
 
     @staticmethod
-    def get_additional_context_for_version_hash(entity: Union[PythonAutoContainerTask, WorkflowBase]) -> List[str]:
+    def get_additional_context_for_version_hash(entity: Union[PythonAutoContainerTask, WorkflowBase]) -> List[bytes]:
         """Get additional context to be used for calculating the version hash."""
         return []
 

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -1252,6 +1252,7 @@ class FlyteRemote(object):
         md5_bytes: bytes,
         serialization_settings: SerializationSettings,
         default_inputs: typing.Optional[Dict[str, typing.Any]] = None,
+        additional_context_bytes: typing.List[bytes] = [],
         *additional_context: str,
     ) -> str:
         """
@@ -1275,6 +1276,8 @@ class FlyteRemote(object):
 
         for s in additional_context:
             h.update(bytes(s, "utf-8"))
+        for b in additional_context_bytes:
+            h.update(b)
 
         if default_inputs:
             try:
@@ -1389,7 +1392,7 @@ class FlyteRemote(object):
                 serialization_settings,
                 default_inputs,
                 *self._get_image_names(entity),
-                *version_hash_additional_context,
+                additional_context_bytes = version_hash_additional_context,
             )
 
         if isinstance(entity, PythonTask):


### PR DESCRIPTION
## Tracking issue

On one hand, this PR is tracked by https://github.com/flyteorg/flyte/issues/5364
On the other hand, it would be productive to refactor the version hash-related PRs to incorporate the feedback here: https://github.com/flyteorg/flytekit/pull/2428#pullrequestreview-2243627484

## Why are the changes needed?

`bytes` is more flexible. This flexibility is relevant when including the serialized input bindings (bytes) in the version hash calculations.

## What changes were proposed in this pull request?

Refactor version_hash_additional_context, which currently uses `str`, to use `bytes`

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
